### PR TITLE
Improve Partial Semantic Version Parsing and Enhance Comparison Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 ~*
 *~
 venv/
+.venv/
 dist/
 build/
 version_parser.egg-info

--- a/version_parser/version.py
+++ b/version_parser/version.py
@@ -97,6 +97,7 @@ class Version:
         return (self._major_version, self._minor_version, self._build_version)
 
     def get_number(self):
+        # Legacy Number support
         filled_major = str(self._major_version).rjust(3, "0")
         filled_minor = str(self._minor_version).rjust(3, "0")
         filled_build = str(self._build_version).rjust(3, "0")
@@ -116,23 +117,14 @@ class Version:
             return f"{self._major_version}.{self._minor_version}.{self._build_version}"
 
         if type is VersionType.NUMBER:
-            # If needed, return the number as before:
-            return self._legacy_number_format()
+            # _legacy_number_format: If needed, return the number as before:
+            return self.get_number() 
 
         if type is VersionType.CLASSNAME_PATCH:
             return f"VM{self._major_version}m{self._minor_version}p{self._build_version}"
 
         #// If we can't determine type, fall back to a standard version string
         return f"v{self._major_version}.{self._minor_version}.{self._build_version}"
-
-    def _legacy_number_format(self):
-        """
-        Recreate the legacy number format (zero-padded to 3 digits each).
-        """
-        filled_major = str(self._major_version).rjust(3, "0")
-        filled_minor = str(self._minor_version).rjust(3, "0")
-        filled_build = str(self._build_version).rjust(3, "0")
-        return int(f"{filled_major}{filled_minor}{filled_build}")
 
     def _parse(self, any_version):
         result_dict = {

--- a/version_parser/version.py
+++ b/version_parser/version.py
@@ -1,7 +1,6 @@
 import re
 from enum import Enum
 
-
 class VersionType(Enum):
     FILENAME = 1
     CLASSNAME = 2
@@ -15,11 +14,15 @@ class VersionType(Enum):
 class Version:
     filename_pattern = re.compile(r"^[v|V]?[\_]?(?P<major>[0-9]+)\_(?P<minor>[0-9]+)\_(?P<build>[0-9]+)$")
     class_pattern = re.compile(r"^[v|V]?M(?P<major>[0-9]+)m(?P<minor>[0-9]+)(?P<type>[p|b])(?P<build>[0-9]+)$")
-    version_pattern = re.compile(r"^[v|V](?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<build>[0-9]+)$")
-    stripped_version_pattern = re.compile(r"^(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<build>[0-9]+)$")
-    number_version_pattern = re.compile(r"^(\d{1,9})$")
+    version_pattern = re.compile(r"^[vV](?P<major>[0-9]+)(?:\.(?P<minor>[0-9]+)(?:\.(?P<build>[0-9]+))?)?$")
+    stripped_version_pattern = re.compile(r"^(?P<major>[0-9]+)(?:\.(?P<minor>[0-9]+)(?:\.(?P<build>[0-9]+))?)?$")
 
-    def __init__(self, raw_version):
+    # Removed number_version_pattern from parsing logic. Instead we use a dedicated constructor.
+    # number_version_pattern = re.compile(r"^(\d{1,9})$")
+
+    def __init__(self, raw_version: str):
+        if isinstance(raw_version, int):
+            raise ValueError("To create a version from a number, use Version.from_number(<int>)")
         result = self._parse(raw_version)
         self._type = result["type"]
         self._major_version = result["major"]
@@ -29,32 +32,69 @@ class Version:
         if isinstance(self._type, ValueError):
             raise self._type
 
+    @classmethod
+    def from_number(cls, number):
+        """
+        Create a Version object from an integer, using the legacy logic.
+        
+        Example:
+            2001 -> v0.2.1
+        """
+        str_num = str(number)
+        if not str_num.isdigit():
+            raise ValueError("from_number expects a positive integer")
+
+        reversed_nr = str_num[::-1]
+        # Split reversed number into chunks of 3
+        version_pieces = [reversed_nr[i:i + 3] for i in range(0, len(reversed_nr), 3)]
+
+        # Extract build
+        build = int(version_pieces[0][::-1])
+        # Extract minor if available
+        minor = int(version_pieces[1][::-1]) if len(version_pieces) > 1 else 0
+        # Extract major if available
+        major = int(version_pieces[2][::-1]) if len(version_pieces) > 2 else 0
+
+        v = cls(f"v{major}.{minor}.{build}")
+        # Set type as NUMBER to preserve old behavior if needed.
+        v._type = VersionType.NUMBER
+        return v
+    
+    def __repr__(self) -> str:
+        return f"Version[{self._major_version}.{self._minor_version}.{self._build_version}]"
+
     def __str__(self):
         return self.get_typed_version(self._type)
 
     def __lt__(self, other):
         assert isinstance(other, self.__class__)
-        return self.get_number() < other.get_number()
+        return self.get_tuple() < other.get_tuple()
 
     def __le__(self, other):
         assert isinstance(other, self.__class__)
-        return self.get_number() <= other.get_number()
+        return self.get_tuple() <= other.get_tuple()
 
     def __eq__(self, other):
-        assert isinstance(other, self.__class__)
-        return self.get_number() == other.get_number()
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self.get_tuple() == other.get_tuple()
 
     def __ge__(self, other):
         assert isinstance(other, self.__class__)
-        return self.get_number() >= other.get_number()
+        return self.get_tuple() >= other.get_tuple()
 
     def __gt__(self, other):
         assert isinstance(other, self.__class__)
-        return self.get_number() > other.get_number()
+        return self.get_tuple() > other.get_tuple()
 
     def __ne__(self, other):
-        assert isinstance(other, self.__class__)
-        return self.get_number() != other.get_number()
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self.get_tuple() != other.get_tuple()
+
+    def get_tuple(self):
+        """Returns the version as a tuple (major, minor, build) for easy comparison."""
+        return (self._major_version, self._minor_version, self._build_version)
 
     def get_number(self):
         filled_major = str(self._major_version).rjust(3, "0")
@@ -76,13 +116,23 @@ class Version:
             return "{}.{}.{}".format(self._major_version, self._minor_version, self._build_version)
 
         if type is VersionType.NUMBER:
-            return self.get_number()
+            # If needed, return the number as before:
+            return self._legacy_number_format()
 
         if type is VersionType.CLASSNAME_PATCH:
             return "VM{}m{}p{}".format(self._major_version, self._minor_version, self._build_version)
 
-    def _reverse(self, num):
-        return str(num)[::-1]
+        #// If we can't determine type, fall back to a standard version string
+        return "v{}.{}.{}".format(self._major_version, self._minor_version, self._build_version)
+
+    def _legacy_number_format(self):
+        """
+        Recreate the legacy number format (zero-padded to 3 digits each).
+        """
+        filled_major = str(self._major_version).rjust(3, "0")
+        filled_minor = str(self._minor_version).rjust(3, "0")
+        filled_build = str(self._build_version).rjust(3, "0")
+        return int("{}{}{}".format(filled_major, filled_minor, filled_build))
 
     def _parse(self, any_version):
         result_dict = {
@@ -94,12 +144,14 @@ class Version:
 
         str_version = str(any_version)
         result = False
+
         if self.filename_pattern.match(str_version):
             result = self.filename_pattern.match(str_version)
             result_dict["type"] = VersionType.FILENAME
 
-        if self.class_pattern.match(str_version):
+        elif self.class_pattern.match(str_version):
             result = self.class_pattern.match(str_version)
+            # By default it's a CLASSNAME:
             result_dict["type"] = VersionType.CLASSNAME
             if result.group("type") == "p":
                 result_dict["type"] = VersionType.CLASSNAME_PATCH
@@ -114,33 +166,12 @@ class Version:
             result = self.stripped_version_pattern.match(str_version)
             result_dict["type"] = VersionType.STRIPPED_VERSION
 
-        elif self.number_version_pattern.match(str_version):
-            result = self.number_version_pattern.match(str_version)
-            result_dict["type"] = VersionType.NUMBER
-
-            reversed_nr = self._reverse(result.group(1))
-            version_pices = [reversed_nr[i:i + 3] for i in range(0, len(reversed_nr), 3)]
-
-            result_dict["build"] = int(self._reverse(version_pices[0]))
-
-            if len(version_pices) > 1:
-                result_dict["minor"] = int(self._reverse(version_pices[1]))
-            else:
-                result_dict["minor"] = 0
-
-            if len(version_pices) > 2:
-                result_dict["major"] = int(self._reverse(version_pices[2]))
-            else:
-                result_dict["major"] = 0
-
-            return result_dict
-
         if not result:
             raise ValueError("Could not parse {}".format(str_version))
 
-        result_dict["major"] = int(result.group("major"))
-        result_dict["minor"] = int(result.group("minor"))
-        result_dict["build"] = int(result.group("build"))
+        result_dict["major"] = int(result.group("major")) if result.group("major") else 0
+        result_dict["minor"] = int(result.group("minor")) if result.group("minor") else 0
+        result_dict["build"] = int(result.group("build")) if result.group("build") else 0
 
         return result_dict
 
@@ -161,22 +192,15 @@ class Version:
 
     def compatible_version_with(self, other_version):
         """
-        See same_version_as, but it doesnt check the build version
-        Args:
-            other_version: Any version String. Supportet VM999m999b999, v_999_999_99 v999.999.999
-        Returns: (bool)
-
+        Checks if major and minor match between self and other_version.
         """
         if isinstance(other_version, Version):
-            result = {
-                "major": other_version.get_major_version(),
-                "minor": other_version.get_minor_version(),
-                "build": other_version.get_build_version()
-            }
+            result_major = other_version.get_major_version()
+            result_minor = other_version.get_minor_version()
         else:
+            # parse as a version string
             result = self._parse(other_version)
+            result_major = result["major"]
+            result_minor = result["minor"]
 
-        if result["major"] == self._major_version and result["minor"] == self._minor_version:
-            return True
-        else:
-            return False
+        return (result_major == self._major_version and result_minor == self._minor_version)

--- a/version_parser/version.py
+++ b/version_parser/version.py
@@ -100,30 +100,30 @@ class Version:
         filled_major = str(self._major_version).rjust(3, "0")
         filled_minor = str(self._minor_version).rjust(3, "0")
         filled_build = str(self._build_version).rjust(3, "0")
-        return int("{}{}{}".format(filled_major, filled_minor, filled_build))
+        return int(f"{filled_major}{filled_minor}{filled_build}")
 
     def get_typed_version(self, type):
         if type is VersionType.FILENAME:
-            return "v_{}_{}_{}".format(self._major_version, self._minor_version, self._build_version)
+            return f"v_{self._major_version}_{self._minor_version}_{self._build_version}"
 
         if type in [VersionType.CLASSNAME, VersionType.CLASSNAME_BUILD]:
-            return "VM{}m{}b{}".format(self._major_version, self._minor_version, self._build_version)
+            return f"VM{self._major_version}m{self._minor_version}b{self._build_version}"
 
         if type is VersionType.VERSION:
-            return "v{}.{}.{}".format(self._major_version, self._minor_version, self._build_version)
+            return f"v{self._major_version}.{self._minor_version}.{self._build_version}"
 
         if type is VersionType.STRIPPED_VERSION:
-            return "{}.{}.{}".format(self._major_version, self._minor_version, self._build_version)
+            return f"{self._major_version}.{self._minor_version}.{self._build_version}"
 
         if type is VersionType.NUMBER:
             # If needed, return the number as before:
             return self._legacy_number_format()
 
         if type is VersionType.CLASSNAME_PATCH:
-            return "VM{}m{}p{}".format(self._major_version, self._minor_version, self._build_version)
+            return f"VM{self._major_version}m{self._minor_version}p{self._build_version}"
 
         #// If we can't determine type, fall back to a standard version string
-        return "v{}.{}.{}".format(self._major_version, self._minor_version, self._build_version)
+        return f"v{self._major_version}.{self._minor_version}.{self._build_version}"
 
     def _legacy_number_format(self):
         """
@@ -132,7 +132,7 @@ class Version:
         filled_major = str(self._major_version).rjust(3, "0")
         filled_minor = str(self._minor_version).rjust(3, "0")
         filled_build = str(self._build_version).rjust(3, "0")
-        return int("{}{}{}".format(filled_major, filled_minor, filled_build))
+        return int(f"{filled_major}{filled_minor}{filled_build}")
 
     def _parse(self, any_version):
         result_dict = {
@@ -167,7 +167,7 @@ class Version:
             result_dict["type"] = VersionType.STRIPPED_VERSION
 
         if not result:
-            raise ValueError("Could not parse {}".format(str_version))
+            raise ValueError(f"Could not parse {str_version}")
 
         result_dict["major"] = int(result.group("major")) if result.group("major") else 0
         result_dict["minor"] = int(result.group("minor")) if result.group("minor") else 0


### PR DESCRIPTION
This PR updates the version parsing logic to handle partial semantic versions more gracefully, ensuring that shorter version strings like v2.3 or v1 (and even just 1) are correctly interpreted as v2.3.0 and 1.0.0 respectively. Previously, the parser did not fully support partial versions—it required explicit major.minor.build structures. The new logic leverages updated regex patterns and a simplified parsing strategy to fill in missing parts with default values (e.g., missing build defaults to 0).

Key Changes:
1.	Enhanced Parsing for Partial Semantic Versions:
By updating and using the following patterns:
```python
version_pattern = re.compile(r"^[vV](?P<major>[0-9]+)(?:\.(?P<minor>[0-9]+)(?:\.(?P<build>[0-9]+))?)?$")
stripped_version_pattern = re.compile(r"^(?P<major>[0-9]+)(?:\.(?P<minor>[0-9]+)(?:\.(?P<build>[0-9]+))?)?$")
```
Versions that omit minor or build parts are now parsed with defaults (e.g., major present but no minor means minor=0, similarly for build).
Examples:
	•	"v1" → v1.0.0
	•	"v2.3" → v2.3.0
	•	"1" → 1.0.0
	•	"2.3" → 2.3.0

2.	Introduction of from_number for Backwards Compatibility:
Previously, some code relied on interpreting plain numbers as versions (e.g. 2001 -> v0.2.1). To keep this legacy functionality available, I introduced Version.from_number(int_value). This method encapsulates the old numeric parsing logic without cluttering the main constructor.
Example:
```python
Version.from_number(2001)  # -> v0.2.1 (legacy logic)
```

3.	Tuple-Based Comparison Instead of Numeric Encoding:
To simplify and clarify version comparisons, the code now compares (major, minor, build) tuples directly rather than converting versions into numeric encodings. Tuple comparison is intuitive and aligns well with semantic versioning principles.
Examples:
	•	(1,2,0) < (1,2,1) is True
	•	(1,2,3) < (1,3,0) is True
        •	(2,2,3) < (2,5,2) is True
        •	(5,2,3) < (2,4,5) is False

4.	Minor changes: 
 - Implements f-string instead of format.
 - Added / Updated tests.
 
Why These Changes?
	•	Flexibility in Parsing: Supporting partial versions (like v2.3 → v2.3.0) was a core goal, making the codebase more robust and user-friendly.
	•	Clarity and Maintainability: Moving legacy numeric parsing into a dedicated method and using tuples for comparison reduces confusion and makes the version handling more transparent.
	•	Backwards Compatibility: Existing code relying on numeric versions can still work via Version.from_number(), ensuring a smooth transition.

Missing:
Update to Readme / Docs (i will/can update Docs, if this should get merged)
Add Typing
